### PR TITLE
Addressing #15 - unmerge/snapshot/rollback implemented in CBM

### DIFF
--- a/fim/graph/abc_property_graph.py
+++ b/fim/graph/abc_property_graph.py
@@ -552,6 +552,14 @@ class ABCGraphImporter(ABC):
         :return:
         """
 
+    @abstractmethod
+    def cast_graph(self, *, graph_id: str) -> ABCPropertyGraph:
+        """
+        Recast a graph with a given node id, checks that graph exists
+        :param graph_id:
+        :return:
+        """
+
     @staticmethod
     def enumerate_graph_nodes(*, graph_file: str, new_graph_file: str, node_id_prop: str = "NodeID") -> None:
         """

--- a/fim/graph/abc_property_graph_constants.py
+++ b/fim/graph/abc_property_graph_constants.py
@@ -55,6 +55,10 @@ class ABCPropertyGraphConstants(ABC):
     PROP_ALLOCATION_CONSTRAINTS = 'AllocationConstraints'
     PROP_SERVICE_ENDPOINT = 'ServiceEndpoint'
     PROP_DETAILS = 'Details'
+    PROP_BQM_NODE_ID = "BQMNodeId"
+    PROP_WORKER_NODE_NAME = 'ResourceNodeName'
+    PROP_INSTANCE_STATE = 'InstanceState'
+    PROP_INSTANCE_NAME = 'InstanceName'
 
     CLASS_NetworkNode = 'NetworkNode'
     CLASS_Component = 'Component'

--- a/fim/graph/data/graph_validation_rules.json
+++ b/fim/graph/data/graph_validation_rules.json
@@ -1,7 +1,7 @@
 [
   {
-    "rule": "MATCH (n:GraphNode {GraphID: $graphId}) RETURN ALL(r IN collect(n) WHERE exists(r.Class) AND exists(r.NodeID))",
-    "msg": "All nodes must have class and NodeID properties"
+    "rule": "MATCH (n:GraphNode {GraphID: $graphId}) RETURN ALL(r IN collect(n) WHERE exists(r.Class) AND exists(r.NodeID) AND exists(r.Type) AND exists(r.Name))",
+    "msg": "All nodes must have Class, Type, Name and NodeID properties"
   },
   {
     "rule": "MATCH (n:GraphNode {GraphID: $graphId}), (m {GraphID: $graphId}) WHERE n.NodeID=m.NodeID AND NOT id(n)=id(m) RETURN count(n) = 0",
@@ -12,15 +12,15 @@
     "msg": "All nodes must be of class NetworkNode, Component, ConnectionPoint, SwitchFabric or Link"
   },
   {
-    "rule": "MATCH (n:NetworkNode {GraphID: $graphId}) RETURN ALL(r IN collect(n) WHERE r.Type IN [\"Server\", \"Switch\"])",
+    "rule": "MATCH (n:NetworkNode {GraphID: $graphId}) RETURN ALL(r IN collect(n) WHERE r.Type IN [\"Server\", \"Switch\", \"VM\", \"Container\", \"NAS\"])",
     "msg": "All NetworkNodes muse be of type Server or Switch"
   },
   {
-    "rule": "MATCH (n:Component {GraphID: $graphId}) RETURN ALL(r IN collect(n) WHERE r.Type IN [\"NIC\", \"SmartNIC\", \"GPU\", \"FPGA\", \"NVMe\"])",
+    "rule": "MATCH (n:Component {GraphID: $graphId}) RETURN ALL(r IN collect(n) WHERE r.Type IN [\"SmartNIC\", \"GPU\", \"FPGA\", \"NVME\", \"SharedNIC\"])",
     "msg": "All Components must be of type NIC, SmartNIC, GPU, FPGA or NVMe"
   },
   {
-    "rule": "MATCH (n:ConnectionPoint {GraphID: $graphId}) RETURN ALL(r IN collect(n) WHERE r.Type IN [\"Port\"])",
+    "rule": "MATCH (n:ConnectionPoint {GraphID: $graphId}) RETURN ALL(r IN collect(n) WHERE r.Type IN [\"AccessPort\", \"TrunkPort\", \"AccessVint\", \"TrunkVint\"])",
     "msg": "All ConnectionPoints must be of type Port"
   },
   {
@@ -30,5 +30,21 @@
   {
     "rule": "MATCH (n:Link {GraphID: $graphId}) RETURN ALL(r IN collect(n) WHERE r.Type IN [\"DAC\", \"Wave\", \"Patch\"])",
     "msg": "All Links must be of type DAC, Patch or Wave"
+  },
+  {
+    "rule": "MATCH(n:ConnectionPoint {GraphID: $graphId}) -[:connects]- (m {GraphID: $graphId}) where m.Class=\"SwitchFabric\" with count(n) as vcps match(c:ConnectionPoint) with vcps, count(c) as cps return cps = vcps",
+    "msg": "All ConnectionPoints must be connected to a SwitchFabric"
+  },
+  {
+    "rule": "MATCH(n:SwitchFabric {GraphID: $graphId}) -[:has]- (m {GraphID: $graphId}) where m.Class=\"NetworkNode\" or m.Class=\"Component\" with count(n) as vcps match(c:SwitchFabric) with vcps, count(c) as cps return cps = vcps",
+    "msg": "All SwitchFabrics must be owned by a Component or a NetworkNode"
+  },
+  {
+    "rule": "MATCH(n:Component {GraphID: $graphId}) -[:has]- (m {GraphID: $graphId}) where m.Class=\"NetworkNode\" with count(n) as vcs match(c:Component) with vcs, count(c) as cs return cs = vcs",
+    "msg": "All Components must be owned by a NetworkNode"
+  },
+  {
+    "rule": "MATCH (o) -[:connects]- (n:Link {GraphID: $graphId}) where o.Class <> \"ConnectionPoint\" return count(o)=0",
+    "msg": "Links can only connect to ConnectionPoints"
   }
 ]

--- a/fim/graph/neo4j_property_graph.py
+++ b/fim/graph/neo4j_property_graph.py
@@ -779,3 +779,10 @@ class Neo4jGraphImporter(ABCGraphImporter):
         self.log.debug(f'Deleting graph {graph_id}')
         with self.driver.session() as session:
             session.run('match (n:GraphNode {GraphID: $graphId })detach delete n', graphId=graph_id)
+
+    def cast_graph(self, *, graph_id: str) -> ABCPropertyGraph:
+
+        assert graph_id is not None
+        neo4jg = Neo4jPropertyGraph(graph_id=graph_id, importer=self, logger=self.log)
+        assert neo4jg.graph_exists()
+        return neo4jg

--- a/fim/graph/networkx_property_graph.py
+++ b/fim/graph/networkx_property_graph.py
@@ -749,3 +749,10 @@ class NetworkXGraphImporter(ABCGraphImporter):
         :return:
         """
         self.storage.del_all_graphs()
+
+    def cast_graph(self, *, graph_id: str) -> ABCPropertyGraph:
+
+        assert graph_id is not None
+        neo4jg = NetworkXPropertyGraph(graph_id=graph_id, importer=self, logger=self.log)
+        assert neo4jg.graph_exists()
+        return neo4jg

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as fh:
 
 setuptools.setup(
   name="fabric_fim",
-  version="0.28",
+  version="0.29",
   author="Ilya Baldin, Komal Thareja",
   description="FABRIC Information Model Library",
   url="https://github.com/fabric-testbed/InformationModel",

--- a/test/neo4j-basic-tests.py
+++ b/test/neo4j-basic-tests.py
@@ -125,6 +125,8 @@ def test_arm_load():
                                  import_dir=neo4j["import_dir"])
     plain_neo4j = n4j_imp.import_graph_from_file_direct(graph_file='../RENCI-ad.graphml')
 
+    plain_neo4j.validate_graph()
+
     cbm = Neo4jCBMGraph(importer=n4j_imp)
 
     site_arm = Neo4jARMGraph(graph=Neo4jPropertyGraph(graph_id=plain_neo4j.graph_id,


### PR DESCRIPTION
Please note that snapshot/rollback are NOT integrated with merge/unmerge calls. The recommended way to implement is to surround merge/unmerge calls in try blocks, do a snapshot right before the merge/unmerge calls and if an exception is raised, do a rollback call in the except block. 

Addressing #15  