### PR TITLE
Tags, measurements and boot scripts

### DIFF
--- a/fim/__init__.py
+++ b/fim/__init__.py
@@ -1,2 +1,2 @@
 #
-__VERSION__ = "1.1b5"
+__VERSION__ = "1.1rc1"

--- a/fim/__init__.py
+++ b/fim/__init__.py
@@ -1,2 +1,2 @@
 #
-__VERSION__ = "1.1rc1"
+__VERSION__ = "1.1rc2"

--- a/fim/graph/abc_property_graph.py
+++ b/fim/graph/abc_property_graph.py
@@ -45,6 +45,8 @@ from fim.slivers.base_sliver import BaseSliver
 from fim.slivers.network_node import NodeSliver, CompositeNodeSliver
 from fim.slivers.network_link import NetworkLinkSliver
 from fim.slivers.path_info import PathInfo, ERO
+from fim.slivers.tags import Tags
+from fim.slivers.measurement_data import MeasurementData
 from fim.slivers.network_service import NetworkServiceSliver, NetworkServiceInfo, NSLayer
 from fim.graph.abc_property_graph_constants import ABCPropertyGraphConstants
 from fim.slivers.gateway import Gateway
@@ -92,7 +94,10 @@ class ABCPropertyGraph(ABCPropertyGraphConstants):
         "structural_info": ABCPropertyGraphConstants.PROP_STRUCTURAL_INFO,
         "ero": ABCPropertyGraphConstants.PROP_ERO,
         "path_info": ABCPropertyGraphConstants.PROP_PATH_INFO,
-        "controller_url": ABCPropertyGraphConstants.PROP_CONTROLLER_URL
+        "controller_url": ABCPropertyGraphConstants.PROP_CONTROLLER_URL,
+        "gateway": ABCPropertyGraphConstants.PROP_GATEWAY,
+        "mf_data": ABCPropertyGraphConstants.PROP_MEAS_DATA,
+        "tags": ABCPropertyGraphConstants.PROP_TAGS
     }
 
     @abstractmethod
@@ -499,6 +504,11 @@ class ABCPropertyGraph(ABCPropertyGraphConstants):
             prop_dict[ABCPropertyGraph.PROP_NODE_MAP] = json.dumps(sliver.node_map)
         # boolean is always there. use json dumps for simplicity
         prop_dict[ABCPropertyGraph.PROP_STITCH_NODE] = json.dumps(sliver.stitch_node)
+        # this is already a JSON dict
+        if sliver.mf_data is not None:
+            prop_dict[ABCPropertyGraph.PROP_MEAS_DATA] = sliver.mf_data.data
+        if sliver.tags is not None:
+            prop_dict[ABCPropertyGraph.PROP_TAGS] = sliver.tags.to_json()
 
         return prop_dict
 
@@ -684,7 +694,11 @@ class ABCPropertyGraph(ABCPropertyGraphConstants):
                               node_map=json.loads(d[ABCPropertyGraph.PROP_NODE_MAP]) if
                               d.get(ABCPropertyGraph.PROP_NODE_MAP, None) is not None else None,
                               stitch_node=json.loads(d[ABCPropertyGraph.PROP_STITCH_NODE]) if
-                              d.get(ABCPropertyGraph.PROP_STITCH_NODE, None) is not None else False
+                              d.get(ABCPropertyGraph.PROP_STITCH_NODE, None) is not None else False,
+                              tags=Tags.from_json(d.get(ABCPropertyGraph.PROP_TAGS, None)),
+                              mf_data=MeasurementData(d[ABCPropertyGraph.PROP_MEAS_DATA])
+                                                      if d.get(ABCPropertyGraph.PROP_MEAS_DATA, None)
+                                                         is not None else None
                               )
 
     @staticmethod

--- a/fim/graph/abc_property_graph.py
+++ b/fim/graph/abc_property_graph.py
@@ -97,7 +97,8 @@ class ABCPropertyGraph(ABCPropertyGraphConstants):
         "controller_url": ABCPropertyGraphConstants.PROP_CONTROLLER_URL,
         "gateway": ABCPropertyGraphConstants.PROP_GATEWAY,
         "mf_data": ABCPropertyGraphConstants.PROP_MEAS_DATA,
-        "tags": ABCPropertyGraphConstants.PROP_TAGS
+        "tags": ABCPropertyGraphConstants.PROP_TAGS,
+        "boot_script": ABCPropertyGraphConstants.PROP_BOOT_SCRIPT
     }
 
     @abstractmethod
@@ -533,6 +534,8 @@ class ABCPropertyGraph(ABCPropertyGraphConstants):
             prop_dict[ABCPropertyGraph.PROP_SITE] = sliver.site
         if sliver.location is not None:
             prop_dict[ABCPropertyGraph.PROP_LOCATION] = sliver.location.to_json()
+        if sliver.boot_script is not None:
+            prop_dict[ABCPropertyGraph.PROP_BOOT_SCRIPT] = sliver.boot_script
 
         return prop_dict
 
@@ -716,7 +719,8 @@ class ABCPropertyGraph(ABCPropertyGraphConstants):
                          allocation_constraints=d.get(ABCPropertyGraph.PROP_ALLOCATION_CONSTRAINTS, None),
                          service_endpoint=d.get(ABCPropertyGraph.PROP_SERVICE_ENDPOINT, None),
                          site=d.get(ABCPropertyGraphConstants.PROP_SITE, None),
-                         location=Location.from_json(d.get(ABCPropertyGraph.PROP_LOCATION, None))
+                         location=Location.from_json(d.get(ABCPropertyGraph.PROP_LOCATION, None)),
+                         boot_script=d.get(ABCPropertyGraph.PROP_BOOT_SCRIPT, None)
                          )
         return n
 

--- a/fim/graph/abc_property_graph_constants.py
+++ b/fim/graph/abc_property_graph_constants.py
@@ -69,6 +69,7 @@ class ABCPropertyGraphConstants(ABC):
     PROP_GATEWAY = "Gateway"
     PROP_TAGS = "Tags"
     PROP_MEAS_DATA = "MeasurementData"
+    PROP_BOOT_SCRIPT = "BootScript"
     # these properties get validated to be valid JSON objects whenever someone validates the graph
     JSON_PROPERTY_NAMES = [PROP_LABELS, PROP_CAPACITIES, PROP_LABEL_DELEGATIONS,
                            PROP_CAPACITY_DELEGATIONS, PROP_LABEL_ALLOCATIONS,

--- a/fim/graph/abc_property_graph_constants.py
+++ b/fim/graph/abc_property_graph_constants.py
@@ -67,13 +67,16 @@ class ABCPropertyGraphConstants(ABC):
     PROP_PATH_INFO = "PathInfo"
     PROP_CONTROLLER_URL = "ControllerURL"
     PROP_GATEWAY = "Gateway"
+    PROP_TAGS = "Tags"
+    PROP_MEAS_DATA = "MeasurementData"
     # these properties get validated to be valid JSON objects whenever someone validates the graph
     JSON_PROPERTY_NAMES = [PROP_LABELS, PROP_CAPACITIES, PROP_LABEL_DELEGATIONS,
                            PROP_CAPACITY_DELEGATIONS, PROP_LABEL_ALLOCATIONS,
                            PROP_CAPACITY_ALLOCATIONS, PROP_RESERVATION_INFO, PROP_STRUCTURAL_INFO,
-                           PROP_ERO, PROP_PATH_INFO, PROP_CAPACITY_HINTS, PROP_GATEWAY]
+                           PROP_ERO, PROP_PATH_INFO, PROP_CAPACITY_HINTS, PROP_GATEWAY,
+                           PROP_TAGS, PROP_MEAS_DATA]
     # these properties cannot be unset
-    NO_UNSET_PROPERTIES = [GRAPH_ID, NODE_ID, PROP_TYPE, PROP_CLASS]
+    NO_UNSET_PROPERTIES = [GRAPH_ID, NODE_ID, PROP_TYPE, PROP_CLASS, PROP_NAME]
 
     CLASS_NetworkNode = 'NetworkNode'
     CLASS_NetworkService = 'NetworkService'

--- a/fim/slivers/base_sliver.py
+++ b/fim/slivers/base_sliver.py
@@ -31,6 +31,8 @@ from abc import ABC, abstractmethod
 
 from fim.slivers.capacities_labels import Capacities, CapacityHints, Labels, ReservationInfo, StructuralInfo
 from fim.slivers.delegations import Delegations
+from fim.slivers.tags import Tags
+from fim.slivers.measurement_data import MeasurementData
 
 
 class BaseSliver(ABC):
@@ -55,6 +57,8 @@ class BaseSliver(ABC):
         self.details = None
         self.node_map = None
         self.stitch_node = False
+        self.tags = None # list of strings, limited in length
+        self.mf_data = None # opaque JSON object limited in length
 
     def set_type(self, resource_type):
         self.resource_type = resource_type
@@ -63,18 +67,21 @@ class BaseSliver(ABC):
         return self.resource_type
 
     def set_name(self, resource_name: str):
+        assert(resource_name is None or isinstance(resource_name, str))
         self.resource_name = resource_name
 
     def get_name(self):
         return self.resource_name
 
     def set_model(self, resource_model: str):
+        assert(resource_model is None or isinstance(resource_model, str))
         self.resource_model = resource_model
 
     def get_model(self):
         return self.resource_model
 
     def set_capacities(self, cap: Capacities) -> None:
+        assert (cap is None or isinstance(cap, Capacities))
         assert(cap is None or isinstance(cap, Capacities))
         self.capacities = cap
 
@@ -144,7 +151,12 @@ class BaseSliver(ABC):
         return self.details
 
     def set_node_map(self, node_map: Tuple[str, str]) -> None:
-        self.node_map = node_map
+        assert(node_map is None or isinstance(node_map, tuple) or
+               isinstance(node_map, list))
+        if node_map is not None:
+            self.node_map = tuple(node_map)
+        else:
+            self.node_map = None
 
     def get_node_map(self) -> Tuple[str, str] or None:
         return tuple(self.node_map) if self.node_map is not None else None
@@ -154,6 +166,21 @@ class BaseSliver(ABC):
 
     def get_stitch_node(self) -> bool:
         return self.stitch_node
+
+    def set_tags(self, tags: Tags) -> None:
+        assert(tags is None or isinstance(tags, Tags))
+        self.tags = tags
+
+    def get_tags(self) -> Tags or None:
+        return self.tags
+
+    def set_mf_data(self, mf_data: MeasurementData or None) -> None:
+        assert(mf_data is None or
+               isinstance(mf_data, MeasurementData))
+        self.mf_data = mf_data
+
+    def get_mf_data(self) -> MeasurementData or None:
+        return self.mf_data
 
     def set_properties(self, **kwargs):
         """

--- a/fim/slivers/measurement_data.py
+++ b/fim/slivers/measurement_data.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Author: Ilya Baldin (ibaldin@renci.org)
+from abc import ABC
+
+import json
+
+
+class MeasurementData:
+    """
+    Measurement data attaches as a property on any node and is an opaque JSON blob
+    """
+    def __init__(self, data: str or None):
+        """
+        data has to be a valid JSON string
+        :param data:
+        """
+        try:
+            if data is not None and len(data) > 0:
+                if len(data) > 1024*1024:
+                    raise MeasurementDataError(f'MeasurementData JSON string is too long ({len(data)} > 1024*1024')
+                json.loads(data)
+                self._data = data
+            else:
+                self._data = "{}"
+        except json.JSONDecodeError:
+            raise MeasurementDataError(f'Unable to decode measurement data {data} as valid JSON ')
+
+    @property
+    def data(self):
+        return self._data
+
+    def __str__(self):
+        return self._data or ""
+
+    def __repr(self):
+        return str(self)
+
+
+class MeasurementDataError(Exception):
+
+    def __init__(self, msg):
+        super().__init__(f'MeasurementDataError: invalid measurement data due to {msg}')

--- a/fim/slivers/network_node.py
+++ b/fim/slivers/network_node.py
@@ -70,6 +70,7 @@ class NodeSliver(BaseSliver):
         self.network_service_info = None
         self.site = None
         self.location = None
+        self.boot_script = None
 
     #
     # Setters are only needed for things we want users to be able to set
@@ -119,6 +120,13 @@ class NodeSliver(BaseSliver):
 
     def get_location(self) -> Location:
         return self.location
+
+    def set_boot_script(self, boot_script: str):
+        assert(boot_script is None or isinstance(boot_script, str))
+        self.boot_script = boot_script
+
+    def get_boot_script(self) -> str:
+        return self.boot_script
 
     @staticmethod
     def type_from_str(ntype: str) -> NodeType or None:

--- a/fim/slivers/tags.py
+++ b/fim/slivers/tags.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Author: Ilya Baldin (ibaldin@renci.org)
+from abc import ABC
+
+import re
+import json
+
+
+class Tags:
+    """
+    A class representing a list of string tags that are no longer than a specified limit
+    """
+    TAG_PATTERN="^[\\w-]{1,255}$"
+    compiled_pattern = re.compile(TAG_PATTERN)
+
+    def __init__(self, *kwargs):
+        """
+        Provide tags as a list or individual parameters
+        :param kwargs:
+        """
+        self.tags = list()
+        for k in kwargs:
+            if isinstance(k, list) or isinstance(k, tuple):
+                for t in k:
+                    Tags._check(t)
+                    self.tags.append(t)
+            else:
+                Tags._check(k)
+                self.tags.append(k)
+
+    def to_json(self) -> str:
+        """
+        Convert list of tags to JSON
+        :return:
+        """
+        return json.dumps(self.tags)
+
+    def __str__(self) -> str:
+        return str(self.tags)
+
+    def __repr(self) -> str:
+        return str(self)
+
+    @classmethod
+    def from_json(cls, json_string: str):
+        """
+        Create a Tags object from JSON string
+        :return:
+        """
+        if json_string is None or len(json_string) == 0 or json_string == "None":
+            return None
+
+        d = json.loads(json_string)
+        ret = cls(d)
+        return ret
+
+    @staticmethod
+    def _check(tag: str):
+        """
+        Check that the tag conforms to our rules - it is a string of regular characters
+        no longer than limit
+        :param tag:
+        :return:
+        """
+        if not isinstance(tag, str) or Tags.compiled_pattern.match(tag) is None:
+            raise TagException(f'Tag {tag} does not match expected pattern {Tags.TAG_PATTERN}')
+
+    def __iter__(self):
+        return iter(self.tags)
+
+
+class TagException(Exception):
+
+    def __init__(self, msg):
+        super().__init__(f'TagException: {msg}')

--- a/fim/slivers/tags.py
+++ b/fim/slivers/tags.py
@@ -89,7 +89,7 @@ class Tags:
             raise TagException(f'Tag {tag} does not match expected pattern {Tags.TAG_PATTERN}')
 
     def __iter__(self):
-        return iter(self.tags)
+        return iter(list(self.tags))
 
 
 class TagException(Exception):

--- a/fim/user/__init__.py
+++ b/fim/user/__init__.py
@@ -15,6 +15,8 @@ import fim.slivers.delegations as dlg
 import fim.graph.abc_property_graph as abcpg
 import fim.slivers.path_info as pinfo
 import fim.slivers.gateway as gw
+import fim.slivers.tags as tgs
+import fim.slivers.measurement_data as mdata
 
 # push some definitions up to simplify import management
 
@@ -49,3 +51,5 @@ GraphFormat = abcpg.GraphFormat
 Gateway = gw.Gateway
 PathInfo = pinfo.PathInfo
 ERO = pinfo.ERO
+Tags = tgs.Tags
+MeasurementData = mdata.MeasurementData

--- a/fim/user/component.py
+++ b/fim/user/component.py
@@ -134,11 +134,14 @@ class Component(ModelElement):
 
     def set_property(self, pname: str, pval: Any):
         """
-        Set a component property
+        Set a component property or unset of pval is None
         :param pname:
         :param pval:
         :return:
         """
+        if pval is None:
+            self.unset_property(pname)
+            return
         comp_sliver = ComponentSliver()
         comp_sliver.set_property(prop_name=pname, prop_val=pval)
         # write into the graph

--- a/fim/user/interface.py
+++ b/fim/user/interface.py
@@ -99,11 +99,14 @@ class Interface(ModelElement):
 
     def set_property(self, pname: str, pval: Any):
         """
-        Set a interface property
+        Set a interface property or unset if pval is None
         :param pname:
         :param pval:
         :return:
         """
+        if pval is None:
+            self.unset_property(pname)
+            return
         if_sliver = InterfaceSliver()
         if_sliver.set_property(prop_name=pname, prop_val=pval)
         # write into the graph

--- a/fim/user/link.py
+++ b/fim/user/link.py
@@ -132,11 +132,14 @@ class Link(ModelElement):
 
     def set_property(self, pname: str, pval: Any):
         """
-        Set a link property
+        Set a link property or unset if pval is None
         :param pname:
         :param pval:
         :return:
         """
+        if pval is None:
+            self.unset_property(pname)
+            return
         link_sliver = NetworkLinkSliver()
         link_sliver.set_property(prop_name=pname, prop_val=pval)
         # write into the graph

--- a/fim/user/model_element.py
+++ b/fim/user/model_element.py
@@ -191,7 +191,7 @@ class ModelElement(ABC):
         if self.__dict__.get('topo', None) is not None:
             if value is None or isinstance(value, MeasurementData):
                 self.set_property('mf_data', value)
-            elif isinstance(value, str):
+            else:
                 self.set_property('mf_data', MeasurementData(value))
 
     def update_labels(self, **kwargs):

--- a/fim/user/model_element.py
+++ b/fim/user/model_element.py
@@ -30,6 +30,7 @@ import enum
 
 from ..graph.abc_property_graph import ABCPropertyGraph
 from ..slivers.capacities_labels import Capacities, Labels
+from ..slivers.measurement_data import MeasurementData
 
 
 class ElementType(enum.Enum):
@@ -104,7 +105,7 @@ class ModelElement(ABC):
     @abstractmethod
     def set_property(self, pname: str, pval):
         """
-        Set a property of a model element
+        Set a property of a model element or unset if pval is None
         :param pname:
         :param paval:
         :return:
@@ -171,6 +172,27 @@ class ModelElement(ABC):
     def node_map(self, value):
         if self.__dict__.get('topo', None) is not None:
             self.set_property('node_map', value)
+
+    @property
+    def tags(self):
+        return self.get_property('tags') if self.__dict__.get('topo', None) is not None else None
+
+    @tags.setter
+    def tags(self, value):
+        if self.__dict__.get('topo', None) is not None:
+            self.set_property('tags', value)
+
+    @property
+    def mf_data(self):
+        return self.get_property('mf_data') if self.__dict__.get('topo', None) is not None else None
+
+    @mf_data.setter
+    def mf_data(self, value):
+        if self.__dict__.get('topo', None) is not None:
+            if value is None or isinstance(value, MeasurementData):
+                self.set_property('mf_data', value)
+            elif isinstance(value, str):
+                self.set_property('mf_data', MeasurementData(value))
 
     def update_labels(self, **kwargs):
         """

--- a/fim/user/model_element.py
+++ b/fim/user/model_element.py
@@ -184,7 +184,8 @@ class ModelElement(ABC):
 
     @property
     def mf_data(self):
-        return self.get_property('mf_data') if self.__dict__.get('topo', None) is not None else None
+        d = self.get_property('mf_data') if self.__dict__.get('topo', None) is not None else None
+        return d.data if d is not None else None
 
     @mf_data.setter
     def mf_data(self, value):

--- a/fim/user/network_service.py
+++ b/fim/user/network_service.py
@@ -351,11 +351,14 @@ class NetworkService(ModelElement):
 
     def set_property(self, pname: str, pval: Any):
         """
-        Set a service property
+        Set a service property or unset of pval is None
         :param pname:
         :param pval:
         :return:
         """
+        if pval is None:
+            self.unset_property(pname)
+            return
         service_sliver = NetworkServiceSliver()
         service_sliver.set_property(prop_name=pname, prop_val=pval)
         # write into the graph

--- a/fim/user/node.py
+++ b/fim/user/node.py
@@ -201,11 +201,14 @@ class Node(ModelElement):
 
     def set_property(self, pname: str, pval: Any):
         """
-        Set a node property
+        Set a node property or unset if pval is None
         :param pname:
         :param pval:
         :return:
         """
+        if pval is None:
+            self.unset_property(pname)
+            return
         node_sliver = NodeSliver()
         node_sliver.set_property(prop_name=pname, prop_val=pval)
         # write into the graph

--- a/fim/user/node.py
+++ b/fim/user/node.py
@@ -181,6 +181,15 @@ class Node(ModelElement):
     def network_services(self):
         return self.__list_network_services()
 
+    @property
+    def boot_script(self):
+        return self.get_property('boot_script') if self.__dict__.get('topo', None) is not None else None
+
+    @boot_script.setter
+    def boot_script(self, value: str):
+        if self.__dict__.get('topo', None) is not None:
+            self.set_property('boot_script', value)
+
     def get_sliver(self) -> NodeSliver:
         """
         Get a deep sliver representation of this node from graph

--- a/test/slice_topology_test.py
+++ b/test/slice_topology_test.py
@@ -218,7 +218,7 @@ class SliceTest(unittest.TestCase):
         n1.mf_data = json.dumps({'k1': ['some', 'measurement', 'configuration']})
         # you are guaranteed that whatever is on mf_data is JSON parsable and can be reconstituted into
         # an object
-        mf_object1 = n1.mf_data.data
+        mf_object1 = n1.mf_data
         self.assertTrue(mf_object1['k1'] == ['some', 'measurement', 'configuration'])
         # when nothing is set, it is None
         self.assertEqual(n2.mf_data, None)
@@ -237,11 +237,9 @@ class SliceTest(unittest.TestCase):
         my_meas_data_object = {'key1': {'key2': ['some', 'config', 'info']}}
         n1.mf_data = my_meas_data_object
 
-        # *** regardless of how you set it, what you get back is a MeasurementData object ***
-        self.assertTrue(isinstance(n1.mf_data, f.MeasurementData))
-        # and to get to the object inside of it, reference .data property (in this case it's a dict)
-        self.assertTrue(isinstance(n1.mf_data.data, dict))
-        mf_object2 = n1.mf_data.data
+        # you get back your object (in this case a dict)
+        self.assertTrue(isinstance(n1.mf_data, dict))
+        mf_object2 = n1.mf_data
         self.assertTrue(mf_object2['key1'] == {'key2': ['some', 'config', 'info']})
 
         class MyClass:

--- a/test/slice_topology_test.py
+++ b/test/slice_topology_test.py
@@ -203,6 +203,16 @@ class SliceTest(unittest.TestCase):
         n1.tags = None
         self.assertEqual(n1.tags, None)
 
+        #boot script on nodes only
+        n1.boot_script = """
+        #!/bin/bash
+        
+        echo *
+        """
+        self.assertTrue("bash" in n1.boot_script)
+        n1.boot_script = None
+        self.assertIsNone(n1.boot_script)
+
         # measurement data on model elements (nodes, links, components, interfaces, network services)
         # can be set simply as json string (string not to exceed 1M)
         n1.mf_data = json.dumps({'k1': ['some', 'measurement', 'configuration']})


### PR DESCRIPTION
Added the ability to
1. Set tags on any element (node, link, service, component or interface). Tags are lists of strings of length under 255. They are immutable. 
```
# assuming n1 is a Node
n1.tags = f.Tags('blue', 'heavy')
# tags are immutable but iterable
self.assertTrue('blue' in n1.tags)
# unset the tags
n1.tags = None
self.assertEqual(n1.tags, None)
```
2. Set measurement framework data  on any element (node, link, service, component or interface). mf_data is a JSON-friendly object representing measurement configuration (combination of dicts, lists). You can set it directly to the `.mf_data` field of e.g. a VM. If the object is not JSON friendly or serializes into a string longer than 1M, you will get a MeasurementDataError exception:
```
        # for most uses, just set the object
        my_meas_data_object = {'key1': {'key2': ['some', 'config', 'info']}}
        n1.mf_data = my_meas_data_object

        # you get back your object (in this case a dict)
        self.assertTrue(isinstance(n1.mf_data, dict))
        mf_object2 = n1.mf_data
        self.assertTrue(mf_object2['key1'] == {'key2': ['some', 'config', 'info']})

        class MyClass:
            def __init__(self, val):
                self.val = val

        # this is not a valid object - json.dumps() will fail on it
        bad_meas_data_object = {'key1': MyClass(3)}
        with self.assertRaises(MeasurementDataError):
            n1.mf_data = bad_meas_data_object

        # most settable properties can be unset by setting them to None 
        n1.mf_data = None
        self.assertIsNone(n1.mf_data)
```
3. Set boot script on Node elements
```
        #boot script on nodes only
        n1.boot_script = """
        #!/bin/bash
        
        echo *
        """
        self.assertTrue("bash" in n1.boot_script)
        n1.boot_script = None
        self.assertIsNone(n1.boot_script)
```