### PR TITLE
Fixing the bug for reloading graph with the same GraphID. Now instead…

### DIFF
--- a/fim/__init__.py
+++ b/fim/__init__.py
@@ -1,2 +1,2 @@
 #
-__VERSION__ = "1.1rc5"
+__VERSION__ = "1.1rc6"

--- a/fim/graph/neo4j_property_graph.py
+++ b/fim/graph/neo4j_property_graph.py
@@ -706,6 +706,8 @@ class Neo4jGraphImporter(ABCGraphImporter):
 
         assert graphml_file is not None
         assert graph_id is not None
+        # delete this graph if it exists
+        self.delete_graph(graph_id=graph_id)
         try:
             with self.driver.session() as session:
                 self.log.debug(f"Loading graph {graph_id} into Neo4j")

--- a/fim/graph/networkx_property_graph.py
+++ b/fim/graph/networkx_property_graph.py
@@ -687,10 +687,8 @@ class NetworkXGraphStorage:
             # check this graph_id isn't already present
             existing_graph_nodes = list(nxq.search_nodes(self.graphs, {'eq': [ABCPropertyGraph.GRAPH_ID, graph_id]}))
             if len(existing_graph_nodes) > 0:
-                # graph already present, warn and exit
-                if self.log is not None:
-                    self.log.warn('Attempting to insert a graph with the same GraphID, skipping')
-                return
+                # graph already present, delete it so we can replace
+                self.del_graph(graph_id)
             # relabel incoming graph nodes to integers, then merge
             temp_graph = nx.convert_node_labels_to_integers(graph, first_label=self.start_id)
             # set/overwrite GraphID property on all nodes
@@ -707,10 +705,8 @@ class NetworkXGraphStorage:
             # check this graph_id isn't already present
             existing_graph_nodes = list(nxq.search_nodes(self.graphs, {'eq': [ABCPropertyGraph.GRAPH_ID, graph_id]}))
             if len(existing_graph_nodes) > 0:
-                # graph already present, warn and exit
-                if self.log is not None:
-                    self.log.warn('Attempting to insert a graph with the same GraphID, skipping')
-                return
+                # graph already present, delete so we can replace
+                self.del_graph(graph_id)
             # relabel incoming graph nodes to integers, then merge
             temp_graph = nx.convert_node_labels_to_integers(graph, first_label=self.start_id)
             self.start_id = self.start_id + len(temp_graph.nodes())

--- a/test/test_load.py
+++ b/test/test_load.py
@@ -1,0 +1,24 @@
+import unittest
+
+import fim.user as fu
+
+
+def load(file_name: str):
+
+    t = fu.ExperimentTopology()
+    t.load(file_name=file_name)
+    return t
+
+
+class LoadTests(unittest.TestCase):
+
+    def testNetworkXLoad(self):
+        """
+        Test for a stupid case where loading silently failed on duplicate graph IDs
+        """
+        print('')
+        t1 = load(file_name="test/before.graphml")
+        print(f"{t1.nodes['n2'].management_ip=}")
+        t2 = load(file_name="test/after.graphml")
+        print(f"{t2.nodes['n2'].management_ip=}")
+        self.assertEqual(str(t2.nodes['n2'].management_ip), '128.163.179.51', "No management IP address found")


### PR DESCRIPTION
… of skipping the load with an error message that can get lost both Neo4j and NetworkX importers delete graph with the same id (if present) and then load; updated test cases and version (1.1rc6) 