### PR TITLE
Ignore files generated by the test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,17 @@ dmypy.json
 #PyCharm
 .idea/
 
+# Files created by tests.
+/LBNL-ad.graphml
+/Network-ad.graphml
+/RENCI-ad.graphml
+/UKY-ad.graphml
+/single-site.graphml
+/two-site.graphml
+/single-site.cyt.json
+/single-site.json
+/two-site.cyt.json
+/two-site.json
+/neo4j/data/databases/
+/neo4j/data/dbms/
+/neo4j/data/transactions/


### PR DESCRIPTION
After running tests, `git status` is a little noisy:

```console
$ git status
On branch rel1.4
Your branch is behind 'origin/rel1.4' by 8 commits, and can be fast-forwarded.
  (use "git pull" to update your local branch)

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	LBNL-ad.graphml
	Network-ad.graphml
	RENCI-ad.graphml
	UKY-ad.graphml
	neo4j/data/databases/
	neo4j/data/dbms/
	neo4j/data/transactions/
	single-site.cyt.json
	single-site.graphml
	single-site.json
	two-site.cyt.json
	two-site.graphml
	two-site.json

nothing added to commit but untracked files present (use "git add" to track)
```

This PR adds those files and directories to `.gitignore`.