### PR TITLE
Add maintenance_info property

### DIFF
--- a/fim/__init__.py
+++ b/fim/__init__.py
@@ -1,2 +1,2 @@
-__VERSION__ = "1.4.0rc5"
+__VERSION__ = "1.4.0rc6"
 

--- a/fim/__init__.py
+++ b/fim/__init__.py
@@ -1,2 +1,2 @@
-__VERSION__ = "1.4.0rc3"
+__VERSION__ = "1.4.0rc5"
 

--- a/fim/graph/abc_property_graph.py
+++ b/fim/graph/abc_property_graph.py
@@ -51,6 +51,7 @@ from fim.slivers.json_data import MeasurementData, UserData, LayoutData
 from fim.slivers.network_service import NetworkServiceSliver, NetworkServiceInfo, NSLayer, MirrorDirection
 from fim.graph.abc_property_graph_constants import ABCPropertyGraphConstants
 from fim.slivers.gateway import Gateway
+from fim.slivers.maintenance_mode import MaintenanceInfo
 
 
 class GraphFormat(Enum):
@@ -105,7 +106,8 @@ class ABCPropertyGraph(ABCPropertyGraphConstants):
         "user_data": ABCPropertyGraphConstants.PROP_USER_DATA,
         "tags": ABCPropertyGraphConstants.PROP_TAGS,
         "flags": ABCPropertyGraphConstants.PROP_FLAGS,
-        "boot_script": ABCPropertyGraphConstants.PROP_BOOT_SCRIPT
+        "boot_script": ABCPropertyGraphConstants.PROP_BOOT_SCRIPT,
+        "maintenance_info": ABCPropertyGraphConstants.PROP_MAINTENANCE_INFO
     }
 
     @abstractmethod
@@ -557,6 +559,8 @@ class ABCPropertyGraph(ABCPropertyGraphConstants):
             prop_dict[ABCPropertyGraph.PROP_SITE] = sliver.site
         if hasattr(sliver, 'location') and sliver.location is not None:
             prop_dict[ABCPropertyGraph.PROP_LOCATION] = sliver.location.to_json()
+        if hasattr(sliver, 'maintenance_info') and sliver.maintenance_info is not None:
+            prop_dict[ABCPropertyGraph.PROP_MAINTENANCE_INFO] = sliver.maintenance_info.to_json()
 
         return prop_dict
 
@@ -760,7 +764,9 @@ class ABCPropertyGraph(ABCPropertyGraphConstants):
                          allocation_constraints=d.get(ABCPropertyGraph.PROP_ALLOCATION_CONSTRAINTS, None),
                          service_endpoint=d.get(ABCPropertyGraph.PROP_SERVICE_ENDPOINT, None),
                          site=d.get(ABCPropertyGraphConstants.PROP_SITE, None),
-                         location=Location.from_json(d.get(ABCPropertyGraph.PROP_LOCATION, None))
+                         location=Location.from_json(d.get(ABCPropertyGraph.PROP_LOCATION, None)),
+                         maintenance_info=
+                         MaintenanceInfo.from_json(d.get(ABCPropertyGraph.PROP_MAINTENANCE_INFO, None))
                          )
         return n
 

--- a/fim/graph/abc_property_graph_constants.py
+++ b/fim/graph/abc_property_graph_constants.py
@@ -76,13 +76,14 @@ class ABCPropertyGraphConstants(ABC):
     PROP_USER_DATA = "UserData"
     PROP_LAYOUT_DATA = "LayoutData"
     PROP_BOOT_SCRIPT = "BootScript"
+    PROP_MAINTENANCE_INFO = "MaintenanceInfo"
     # these properties get validated to be valid JSON objects whenever someone validates the graph
     JSON_PROPERTY_NAMES = [PROP_LABELS, PROP_CAPACITIES, PROP_LABEL_DELEGATIONS,
                            PROP_CAPACITY_DELEGATIONS, PROP_LABEL_ALLOCATIONS,
                            PROP_CAPACITY_ALLOCATIONS, PROP_RESERVATION_INFO, PROP_STRUCTURAL_INFO,
                            PROP_ERO, PROP_PATH_INFO, PROP_CAPACITY_HINTS, PROP_GATEWAY,
                            PROP_TAGS, PROP_FLAGS, PROP_MEAS_DATA, PROP_USER_DATA, PROP_LAYOUT_DATA,
-                           PROP_PEER_LABELS]
+                           PROP_PEER_LABELS, PROP_MAINTENANCE_INFO]
     # these properties cannot be unset
     NO_UNSET_PROPERTIES = [GRAPH_ID, NODE_ID, PROP_TYPE, PROP_CLASS, PROP_NAME]
 

--- a/fim/slivers/json_data.py
+++ b/fim/slivers/json_data.py
@@ -101,7 +101,7 @@ class JSONData(ABC):
 
 class MeasurementData(JSONData):
 
-    MAX_SIZE = 10240
+    MAX_SIZE = 4096
 
     def __init__(self, data: Any or None):
         super().__init__(data, MeasurementDataError)
@@ -109,7 +109,7 @@ class MeasurementData(JSONData):
 
 class UserData(JSONData):
 
-    MAX_SIZE = 10240
+    MAX_SIZE = 2048
 
     def __init__(self, data: Any or None):
         super().__init__(data, UserDataError)

--- a/fim/slivers/maintenance_mode.py
+++ b/fim/slivers/maintenance_mode.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# Author: Ilya Baldin (ibaldin@renci.org)
+import dataclasses
+from typing import List, Tuple, Any, Dict
+import enum
+from dataclasses import dataclass
+from datetime import datetime, timedelta, date, time, timezone
+import json
+
+
+class MaintenanceState(enum.Enum):
+    Active = enum.auto()
+    PreMaint = enum.auto()
+    Maint = enum.auto()
+    Unknown = enum.auto()
+
+    def __repr__(self):
+        return self.name
+
+    def __str__(self):
+        return self.name
+
+    @classmethod
+    def from_string(cls, s: str):
+        for ms in MaintenanceState:
+            if s == ms.name:
+                return cls(ms)
+        return None
+
+
+class EnhancedJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if dataclasses.is_dataclass(o):
+            return dataclasses.asdict(o)
+        if isinstance(o, MaintenanceState):
+            return str(o)
+        if isinstance(o, (datetime, date, time)):
+            return o.isoformat()
+        return super().default(o)
+
+
+@dataclass(eq=True)
+class MaintenanceEntry:
+    state: MaintenanceState
+    deadline: datetime = None # when it starts
+    expected_end: datetime = None # how long it may be
+
+    def __init__(self, state: MaintenanceState or str,
+                 deadline: datetime or str or None = None,
+                 expected_end: datetime or str or None = None):
+        if isinstance(state, MaintenanceState):
+            self.state = state
+        else:
+            self.state = MaintenanceState.from_string(state)
+
+        if isinstance(deadline, datetime):
+            self.deadline = deadline
+        elif deadline:
+            self.deadline = datetime.fromisoformat(deadline)
+
+        if isinstance(expected_end, datetime):
+            self.expected_end = expected_end
+        elif expected_end:
+            self.expected_end = datetime.fromisoformat(expected_end)
+
+
+class MaintenanceModeException(Exception):
+    def __init(self, msg: str):
+        super().__init__(msg)
+
+
+# ABQM maintenance information is a dictionary
+class MaintenanceInfo:
+
+    def __init__(self):
+        self._nodes = dict()
+        # prevent modifications
+        self._lock = False
+
+    def _set(self, d: Dict):
+        self._nodes = d
+
+    def finalize(self):
+        """
+        Prevent further modifications - used after the object is
+        assigned to a property
+        """
+        self._lock = True
+
+    def add(self, name: str, minfo: MaintenanceEntry) -> None:
+        """
+        Add entry
+        """
+        if self._lock:
+            raise MaintenanceModeException("Unable to modify a finalized object, recreate and reassign")
+        self._nodes[name] = minfo
+
+    def get(self, name: str) -> MaintenanceEntry or None:
+        return self._nodes.get(name)
+
+    def rem(self, name: str) -> None:
+        """
+        Remove entry
+        """
+        if self._lock:
+            raise MaintenanceModeException("Unable to modify a finalized object, recreate and reassign")
+        self._nodes.pop(name)
+
+    def pop(self, name: str) -> MaintenanceEntry:
+        """
+        Pop an entry returning maintenance info
+        """
+        if self._lock:
+            raise MaintenanceModeException("Unable to modify a finalized object, recreate and reassign")
+        return self._nodes.pop(name)
+
+    def to_json(self) -> str:
+        """
+        Convert structure to JSON
+        """
+        if not self._lock:
+            raise MaintenanceModeException("Object should be finalized prior to serializing")
+        return json.dumps(self._nodes, cls=EnhancedJSONEncoder)
+
+    def copy(self):
+        """
+        Copy an instance of the object but don't finalize
+        """
+        t = MaintenanceInfo()
+        t._nodes = self._nodes.copy()
+        return t
+
+    @classmethod
+    def from_json(cls, json_string: str):
+        """
+        Convert into structure from JSON
+        """
+        if json_string is None or len(json_string) == 0:
+            return None
+        o = json.loads(json_string)
+        ret = cls()
+        ret._set({k: MaintenanceEntry(**v) for (k, v) in o.items()})
+        ret.finalize()
+        return ret
+
+    def __str__(self):
+        return self.to_json()
+

--- a/fim/slivers/maintenance_mode.py
+++ b/fim/slivers/maintenance_mode.py
@@ -153,6 +153,29 @@ class MaintenanceInfo:
         t._nodes = self._nodes.copy()
         return t
 
+    def list_names(self) -> List[str]:
+        """
+        List the names of the nodes in maintenance
+        """
+        return list(self._nodes.keys())
+
+    def list_details(self) -> List[Tuple[str, Any]]:
+        """
+        Return a list of tuples with node name and maintenance state details
+        """
+        return list(self._nodes.copy().items())
+
+    def iter(self):
+        """
+        Generate an item iterator on a finalized object, so you can do
+        for i in minfo.iter():
+          print(i)
+        """
+        if not self._lock:
+            raise MaintenanceModeException("Object should be finalized prior to attempting iteration")
+        for i in self._nodes.items():
+            yield i
+
     @classmethod
     def from_json(cls, json_string: str):
         """

--- a/fim/slivers/network_node.py
+++ b/fim/slivers/network_node.py
@@ -30,6 +30,7 @@ from recordclass import recordclass
 from fim.slivers.capacities_labels import Location
 from .base_sliver import BaseSliver
 from .topology_diff import TopologyDiff, TopologyDiffTuple
+from fim.slivers.maintenance_mode import MaintenanceInfo
 
 
 class NodeType(enum.Enum):
@@ -99,6 +100,7 @@ class NodeSliver(BaseSliver):
         self.network_service_info = None
         self.site = None
         self.location = None
+        self.maintenance_info = None
 
     #
     # Setters are only needed for things we want users to be able to set
@@ -148,6 +150,15 @@ class NodeSliver(BaseSliver):
 
     def get_location(self) -> Location:
         return self.location
+
+    def set_maintenance_info(self, maintenance_info: MaintenanceInfo):
+        assert(maintenance_info is None or isinstance(maintenance_info, MaintenanceInfo))
+        if maintenance_info:
+            maintenance_info.finalize()
+        self.maintenance_info = maintenance_info
+
+    def get_maintenance_info(self) -> MaintenanceInfo:
+        return self.maintenance_info
 
     def diff(self, other_sliver) -> TopologyDiff or None:
         if not other_sliver:

--- a/fim/user/node.py
+++ b/fim/user/node.py
@@ -41,6 +41,7 @@ from ..slivers.network_node import NodeType
 from ..slivers.network_service import ServiceType, NetworkServiceInfo
 from ..slivers.component_catalog import ComponentModelType
 from ..slivers.capacities_labels import CapacityHints, Location
+from ..slivers.maintenance_mode import MaintenanceInfo
 
 
 class Node(ModelElement):
@@ -164,6 +165,19 @@ class Node(ModelElement):
     def location(self, value: Location):
         if self.__dict__.get('topo', None) is not None:
             self.set_property('location', value)
+
+    @property
+    def maintenance_info(self):
+        """
+        Do not try to manipulate maintenance_info (PerNodeMaintenanceInfo) via this property,
+        assign a complete object or unset
+        """
+        return self.get_property('maintenance_info') if self.__dict__.get('topo', None) is not None else None
+
+    @maintenance_info.setter
+    def maintenance_info(self, value: MaintenanceInfo):
+        if self.__dict__.get('topo', None) is not None:
+            self.set_property('maintenance_info', value)
 
     @property
     def components(self):

--- a/test/maintenance_test.py
+++ b/test/maintenance_test.py
@@ -1,0 +1,36 @@
+import unittest
+
+from fim.slivers.maintenance_mode import MaintenanceInfo, MaintenanceEntry, \
+    MaintenanceState, MaintenanceModeException
+from datetime import datetime, timedelta
+
+
+class TestMaintenance(unittest.TestCase):
+
+    def test_maintenance(self):
+        a = MaintenanceInfo()
+        a.add(name='node1', minfo=MaintenanceEntry(MaintenanceState.Active))
+        a.add(name='node111', minfo=MaintenanceEntry(MaintenanceState.PreMaint, deadline=datetime.now()))
+        a.add(name='node112', minfo=MaintenanceEntry(MaintenanceState.Maint, deadline=datetime.now(),
+                                                     expected_end=datetime.now() + timedelta(days=1)))
+        with self.assertRaises(MaintenanceModeException):
+            # can't serialize unfinalized object
+            a.to_json()
+
+        a.finalize()
+        j = a.to_json()
+        b = MaintenanceInfo.from_json(j)
+
+        self.assertEqual(a.get('node1'), b.get('node1'))
+        self.assertEqual(a.get('node111'), b.get('node111'))
+        self.assertEqual(a.get('node112'), b.get('node112'))
+
+        c = a.copy()
+        self.assertEqual(a.get('node1'), c.get('node1'))
+        self.assertEqual(a.get('node111'), c.get('node111'))
+        self.assertEqual(a.get('node112'), c.get('node112'))
+
+        with self.assertRaises(MaintenanceModeException):
+            # can't serialize unfinalized object
+            # copy constructor doesn't finalize
+            c.to_json()

--- a/test/maintenance_test.py
+++ b/test/maintenance_test.py
@@ -10,7 +10,8 @@ class TestMaintenance(unittest.TestCase):
     def test_maintenance(self):
         a = MaintenanceInfo()
         a.add(name='node1', minfo=MaintenanceEntry(MaintenanceState.Active))
-        a.add(name='node111', minfo=MaintenanceEntry(MaintenanceState.PreMaint, deadline=datetime.now()))
+        mi = MaintenanceEntry(MaintenanceState.PreMaint, deadline=datetime.now())
+        a.add(name='node111', minfo=mi)
         a.add(name='node112', minfo=MaintenanceEntry(MaintenanceState.Maint, deadline=datetime.now(),
                                                      expected_end=datetime.now() + timedelta(days=1)))
         with self.assertRaises(MaintenanceModeException):
@@ -24,6 +25,13 @@ class TestMaintenance(unittest.TestCase):
         self.assertEqual(a.get('node1'), b.get('node1'))
         self.assertEqual(a.get('node111'), b.get('node111'))
         self.assertEqual(a.get('node112'), b.get('node112'))
+
+        self.assertIn('node111', a.list_names())
+        self.assertIn(('node111', mi),
+                      a.list_details())
+
+        #for i in a.iter():
+        #    print(i)
 
         c = a.copy()
         self.assertEqual(a.get('node1'), c.get('node1'))

--- a/test/sliver_test.py
+++ b/test/sliver_test.py
@@ -9,6 +9,7 @@ from fim.slivers.path_info import ERO, PathInfo, Path
 from fim.slivers.capacities_labels import Capacities, Labels, CapacityHints, Location, LabelException, Flags
 from fim.slivers.tags import Tags
 from fim.slivers.gateway import Gateway, GatewayException
+from fim.slivers.maintenance_mode import MaintenanceInfo, MaintenanceState, MaintenanceEntry
 
 
 class TestSlivers(unittest.TestCase):
@@ -45,11 +46,16 @@ class TestSlivers(unittest.TestCase):
         self.assertEqual(len(acs.get_devices_by_type(ComponentType.SmartNIC)), 1)
 
     def testNodeSliver(self):
+        minfo = MaintenanceInfo()
+        minfo.add('node1', minfo=MaintenanceEntry(state=MaintenanceState.Active))
         ns = NodeSliver()
         ns.set_properties(name='node1', type=NodeType.Server,
-                          management_ip='192.168.1.1')
+                          management_ip='192.168.1.1',
+                          maintenance_info=minfo)
         with self.assertRaises(ValueError) as ve:
             ns.set_property('management_ip', '192.168.1.x')
+
+        self.assertEqual(ns.get_maintenance_info().get('node1').state, MaintenanceState.Active)
 
     def testNetworkServiceSliver(self):
         ns = NetworkServiceSliver()


### PR DESCRIPTION
Addresses #153 by adding a maintenance_info property onto node-like objects; see test/slice_topology_test.py line 644 for how to use


Example of how to use it. `maintenance_info` propery is valid for NetworkNodes and CompositeNodes (within a Topology object):
```
        # maintenance mode - the object needs to be constructed prior to being assigned to the property
        # along with the state (MaintenanceState) you can specify datetime deadline and expected_end (presumed in UTC)
        minfo = MaintenanceInfo()
        minfo.add(name=n1.name, minfo=MaintenanceEntry(state=MaintenanceState.PreMaint, deadline=datetime.now(), expected_end=datetime.now() + timedelta(days=1))
        n1.maintenance_info = minfo

        self.assertEqual(n1.maintenance_info.get(n1.name).state, MaintenanceState.PreMaint)
        # check it is finalized
        self.assertEqual(n1.maintenance_info._lock, True)

        # try to modify after assignment
        with self.assertRaises(MaintenanceModeException):
            n1.maintenance_info.add(name='n3', minfo=MaintenanceEntry(state=MaintenanceState.PreMaint,
                                                                      deadline=datetime.datetime.now()))
```
if you are operating on slivers, you can do this:
```
        minfo = MaintenanceInfo()
        minfo.add('node1', minfo=MaintenanceEntry(state=MaintenanceState.Active))
        ns = NodeSliver()
        ns.set_properties(name='node1', type=NodeType.Server,
                          management_ip='192.168.1.1',
                          maintenance_info=minfo)
        with self.assertRaises(ValueError) as ve:
            ns.set_property('management_ip', '192.168.1.x')

        self.assertEqual(ns.get_maintenance_info().get('node1').state, MaintenanceState.Active)
```
`maintenance_info` property on NetworkNodes and CompositeNodes carries a dictionary keyed by node name so it looks like this:
```
class MaintenanceEntry:
    state: MaintenanceState
    deadline: datetime = None # when it starts
    expected_end: datetime = None # how long it may be

minfo = MaintenanceInfo()
minfo.add(name='node1', minfo=MaintenanceEntry(state=MaintenanceState.PreMaint, deadline=datetime.now(), expected_end=datetime.now() + timedelta(days=1))
minfo.add(name='node2', minfo=MaintenanceEntry(state=MaintenanceState.PreMaint, deadline=datetime.now(), expected_end=datetime.now() + timedelta(days=1))
minfo.add(name='node3', minfo=MaintenanceEntry(state=MaintenanceState.PreMaint, deadline=datetime.now(), expected_end=datetime.now() + timedelta(days=1))
minfo.add(name='node4', minfo=MaintenanceEntry(state=MaintenanceState.PreMaint, deadline=datetime.now(), expected_end=datetime.now() + timedelta(days=1))

composite_node.maintenance_info = minfo
```

In PyPi as `fabric_fim==1.4.0rc5`