### PR TITLE
Fix for diffing nodes and network services where only labels or capacities change

### DIFF
--- a/fim/__init__.py
+++ b/fim/__init__.py
@@ -1,5 +1,5 @@
 """
 FABRIC Information Model library and utilities
 """
-__VERSION__ = "1.5.1"
+__VERSION__ = "1.5.2"
 __version__ = __VERSION__

--- a/fim/slivers/network_node.py
+++ b/fim/slivers/network_node.py
@@ -201,13 +201,13 @@ class NodeSliver(BaseSliver):
             comp_removed = set(self.attached_components_info.devices.values())
 
         if self.network_service_info and other_sliver.network_service_info:
-            diff_ns = self._dict_diff(other_sliver.network_service_info.services,
-                                      other_sliver.network_service_info.services)
+            diff_ns = self._dict_diff(other_sliver.network_service_info.network_services,
+                                      other_sliver.network_service_info.network_services)
             ns_added = set(diff_ns['added'].values())
             ns_removed = set(diff_ns['removed'].values())
             # there are common network services so we check their properties
-            ns_common = self._dict_common(self.network_service_info.services,
-                                          other_sliver.network_service_info.services)
+            ns_common = self._dict_common(self.network_service_info.network_services,
+                                          other_sliver.network_service_info.network_services)
             for nsA in ns_common.values():
                 nsB = other_sliver.network_service_info.get_network_service(nsA.resource_name)
                 # compare properties
@@ -216,14 +216,14 @@ class NodeSliver(BaseSliver):
                     ns_modified.append((nsA, flag))
 
         if not self.network_service_info and other_sliver.network_service_info:
-            ns_added = set(other_sliver.network_service_info.services.values())
+            ns_added = set(other_sliver.network_service_info.network_services.values())
 
         if self.network_service_info and not other_sliver.network_service_info:
-            ns_removed = set(self.network_service_info.services.values())
+            ns_removed = set(self.network_service_info.network_services.values())
 
         if len(comp_added) > 0 or len(comp_removed) > 0 or \
                 len(ns_removed) > 0 or len(ns_added) > 0 or \
-                len(comp_modified) > 0 or len(ns_modified) > 0:
+                len(comp_modified) > 0 or len(ns_modified) > 0 or len(self_modified) > 0:
             return TopologyDiff(added=TopologyDiffTuple(components=comp_added, services=ns_added, interfaces=set(),
                                                         nodes=set()),
                                 removed=TopologyDiffTuple(components=comp_removed, services=ns_removed,

--- a/fim/slivers/network_service.py
+++ b/fim/slivers/network_service.py
@@ -393,7 +393,7 @@ class NetworkServiceSliver(BaseSliver):
         if self.interface_info and not other_sliver.interface_info:
             ifs_removed = set(self.interface_info.interfaces.values())
 
-        if len(ifs_added) > 0 or len(ifs_removed) > 0 or len(ifs_modified) > 0:
+        if len(self_modified) > 0 or len(ifs_added) > 0 or len(ifs_removed) > 0 or len(ifs_modified) > 0:
             return TopologyDiff(added=TopologyDiffTuple(components=set(), services=set(), interfaces=ifs_added,
                                                         nodes=set()),
                                 removed=TopologyDiffTuple(components=set(), services=set(),

--- a/test/modify_test.py
+++ b/test/modify_test.py
@@ -280,6 +280,28 @@ class ModifyTest(unittest.TestCase):
         #print(f'\nStarting Topo {self.topoA}')
         #print(f'\nFinal Topo {self.topoB}')
 
+    def testSimpleSliverDiff(self):
+        print('*** Simple Sliver diff test')
+        # just test to network services different in labels
+        tA = f.ExperimentTopology()
+        na = tA.add_node(name='nodeA', site='UKY')
+        ca = na.add_component(name='nic3', ctype=ComponentType.SharedNIC, model='ConnectX-6')
+        ns = na.add_network_service(name='ne1', nstype=ServiceType.FABNetv4, interfaces=na.interface_list,
+                                    labels=Labels(ipv4='192.168.1.1'))
+        nsS1 = tA.graph_model.build_deep_ns_sliver(node_id=ns.node_id)
+        nS1 = tA.graph_model.build_deep_node_sliver(node_id=na.node_id)
+        ns.labels = Labels(ipv4='192.168.1.2')
+        ns.capacities = Capacities(bw=100)
+        na.labels = Labels(ipv4='10.100.1.1')
+        nsS2 = tA.graph_model.build_deep_ns_sliver(node_id=ns.node_id)
+        nS2 = tA.graph_model.build_deep_node_sliver(node_id=na.node_id)
+        ns_diff = nsS1.diff(nsS2)
+        node_diff = nS1.diff(nS2)
+        self.assertEqual(ns_diff.modified.services[0][1], WhatsModifiedFlag.LABELS | WhatsModifiedFlag.CAPACITIES)
+        self.assertEqual(node_diff.modified.services[0][1], WhatsModifiedFlag.LABELS | WhatsModifiedFlag.CAPACITIES)
+        self.assertEqual(node_diff.modified.nodes[0][1], WhatsModifiedFlag.LABELS)
+        print(f' ****** {node_diff=}')
+
     def testSliverDiffs(self):
 
         print('*** Sliver diff test')


### PR DESCRIPTION
Supposed to have been addressed in #174 

published as fabric_fim==1.5.2